### PR TITLE
Modify regex to find defaultConfig

### DIFF
--- a/lib/fastlane/plugin/android_update_package_identifier/actions/android_update_package_identifier_action.rb
+++ b/lib/fastlane/plugin/android_update_package_identifier/actions/android_update_package_identifier_action.rb
@@ -11,7 +11,8 @@ module Fastlane
         File.open(path,"r+") do |file|
           text = File.read(file)
           UI.message("Changing build config at #{path} to have applicationId of #{identifier}")
-          config_contents = text[/defaultConfig (\{(?:\{??[^\{]*?\}))/, 1]
+          config_contents = config_contents = text[/defaultConfig (\{(?:[^\{]*(?:\{[^\{]*?\})?)*?\})/, 1]
+
           new_config_contents = config_contents.gsub(/(?<=applicationId \").*?(?=\")/, identifier)
           new_contents = text.gsub(config_contents, new_config_contents)
           file.puts new_contents

--- a/lib/fastlane/plugin/android_update_package_identifier/actions/android_update_package_identifier_action.rb
+++ b/lib/fastlane/plugin/android_update_package_identifier/actions/android_update_package_identifier_action.rb
@@ -11,10 +11,10 @@ module Fastlane
         File.open(path,"r+") do |file|
           text = File.read(file)
           UI.message("Changing build config at #{path} to have applicationId of #{identifier}")
-          config_contents = config_contents = text[/defaultConfig (\{(?:[^\{]*(?:\{[^\{]*?\})?)*?\})/, 1]
-
+          config_contents = text[/defaultConfig (\{(?:[^\{]*(?:\{[^\{]*?\})?)*?\})/, 1]
           new_config_contents = config_contents.gsub(/(?<=applicationId \").*?(?=\")/, identifier)
           new_contents = text.gsub(config_contents, new_config_contents)
+          file.truncate(0)
           file.puts new_contents
         end
       end

--- a/lib/fastlane/plugin/android_update_package_identifier/version.rb
+++ b/lib/fastlane/plugin/android_update_package_identifier/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module AndroidUpdatePackageIdentifier
-    VERSION = "0.1.3"
+    VERSION = "0.1.4"
   end
 end

--- a/lib/fastlane/plugin/android_update_package_identifier/version.rb
+++ b/lib/fastlane/plugin/android_update_package_identifier/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module AndroidUpdatePackageIdentifier
-    VERSION = "0.1.4"
+    VERSION = "0.1.5"
   end
 end


### PR DESCRIPTION
This PR updates the regex to match with defaultConfig with nested brackets. 

Example:
```
  defaultConfig {
        applicationId "my.app"
        minSdk 28
        targetSdk 33
        versionCode 1
        versionName "1.0.1"
        vectorDrawables {
            useSupportLibrary true
        }
    }
```